### PR TITLE
Overhaul: fix critical bugs, improve UX, add dark mode, add Docker de…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+.next
+.git
+.gitignore
+README.md
+TODO.md
+.claude
+Dockerfile
+docker-compose.yml
+.dockerignore
+npm-debug.log*
+.vercel

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM node:20-alpine AS base
+
+FROM base AS deps
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+FROM base AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV HOSTNAME="0.0.0.0"
+ENV PORT=3000
+
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
+
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/app/api/pruefungsplan/fetch.ts
+++ b/app/api/pruefungsplan/fetch.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+import { ExamEntry } from "@/types/exam";
+import { normalizeRow, mapRowToEntry } from "@/utils/pdfParser";
+import { DEFAULT_HIDDEN_COLUMNS } from "@/config/tableConfig";
+
+const WHS_URL = "https://www.w-hs.de/downloads/sdl-eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3NDAyNjExMzMsImV4cCI6MTc3MjgxMTEzMywiYXV0aCI6eyJhdXRoZW50aWNhdGlvbk1ldGhvZCI6IlNlY3JldCIsImF1dGhvclVSTDNcIjoiKGFsbG93ZWQpfX0.eKw5w1Q3yG7xY8F2jL9kM3nP4oR6sT7uV8wX9yA0bC1d/PP_2026_IB_-_Aushang.pdf";
+
+export async function POST() {
+  try {
+    const response = await fetch(WHS_URL, {
+      headers: {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch PDF: ${response.statusText}`);
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+
+    const pdfDoc = new (await import("pdf-tables-parser")).PdfDocument({
+      hasTitles: true,
+      threshold: 1.5,
+      maxStrLength: 100,
+      ignoreTexts: [],
+    });
+
+    await pdfDoc.load(buffer);
+
+    const allEntries: ExamEntry[] = [];
+    pdfDoc.pages.forEach((page) => {
+      page.tables.forEach((table) => {
+        table.data.forEach((row) => {
+          const cols = normalizeRow(row.flat());
+          const entry = mapRowToEntry(cols);
+          if (
+            entry &&
+            !["mid", "MID", "kuerzel", "Kürzel"].includes(entry.mid.toLowerCase())
+          ) {
+            allEntries.push(entry);
+          }
+        });
+      });
+    });
+
+    return NextResponse.json({
+      timestamp: Date.now(),
+      success: true,
+      count: allEntries.length,
+      data: allEntries,
+      hiddenColumns: DEFAULT_HIDDEN_COLUMNS,
+      headers: ["mid", "kuerzel", "po", "lp", "datum", "zeit", "pruefungsform", "pruefungsdauer", "modul", "pruefer"],
+    });
+  } catch (error) {
+    console.error("Error fetching and parsing PDF:", error);
+    return NextResponse.json(
+      { success: false, error: "Prüfungsplan konnte nicht geladen werden" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/pruefungsplan/route.ts
+++ b/app/api/pruefungsplan/route.ts
@@ -1,0 +1,116 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ExamEntry } from "@/types/exam";
+import { normalizeRow, mapRowToEntry } from "@/utils/pdfParser";
+
+const LOCAL_PDF_URL = "https://www.w-hs.de/downloads/sdl-eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3NDAyNjExMzMsImV4cCI6MTc3MjgxMTEzMywiYXV0aCI6eyJhdXRoZW50aWNhdGlvbk1ldGhvZCI6IlNlY3JldCIsImF1dGhvclVSTDNcIjoiKGFsbG93ZWQpfX0.eKw5w1Q3yG7xY8F2jL9kM3nP4oR6sT7uV8wX9yA0bC1d/PP_2026_IB_-_Aushang.pdf";
+
+let cachedData: ExamEntry[] | null = null;
+let cachedAt: number = 0;
+const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+
+function isCacheValid(): boolean {
+  return cachedData !== null && (Date.now() - cachedAt) < CACHE_TTL;
+}
+
+async function fetchAndParsePdf(url: string): Promise<ExamEntry[]> {
+  const response = await fetch(url, {
+    headers: {
+      "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch PDF: ${response.status} ${response.statusText}`);
+  }
+
+  const arrayBuffer = await response.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+
+  const { PdfDocument } = await import("pdf-tables-parser");
+  const pdfDoc = new PdfDocument({
+    hasTitles: true,
+    threshold: 1.5,
+    maxStrLength: 100,
+    ignoreTexts: [],
+  });
+
+  await pdfDoc.load(buffer);
+
+  const allEntries: ExamEntry[] = [];
+  pdfDoc.pages.forEach((page) => {
+    page.tables.forEach((table) => {
+      table.data.forEach((row) => {
+        const cols = normalizeRow(row.flat());
+        const entry = mapRowToEntry(cols);
+        if (
+          entry &&
+          !["mid", "MID", "kuerzel", "Kürzel"].includes(entry.mid.toLowerCase())
+        ) {
+          allEntries.push(entry);
+        }
+      });
+    });
+  });
+
+  return allEntries;
+}
+
+export async function GET() {
+  try {
+    if (isCacheValid()) {
+      return NextResponse.json({
+        success: true,
+        data: cachedData,
+        cached: true,
+      });
+    }
+
+    const data = await fetchAndParsePdf(LOCAL_PDF_URL);
+    cachedData = data;
+    cachedAt = Date.now();
+
+    return NextResponse.json({
+      success: true,
+      data,
+      cached: false,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    console.error("Error in GET /api/pruefungsplan:", message);
+    return NextResponse.json(
+      { success: false, error: "Prüfungsplan konnte nicht geladen werden", details: message },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { url } = body;
+
+    if (!url || typeof url !== "string") {
+      return NextResponse.json(
+        { success: false, error: "URL ist erforderlich" },
+        { status: 400 }
+      );
+    }
+
+    const data = await fetchAndParsePdf(url);
+    cachedData = data;
+    cachedAt = Date.now();
+
+    return NextResponse.json({
+      success: true,
+      data,
+      count: data.length,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    console.error("Error in POST /api/pruefungsplan:", message);
+    return NextResponse.json(
+      { success: false, error: "Prüfungsplan konnte nicht geladen werden", details: message },
+      { status: 500 }
+    );
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -81,6 +81,32 @@
   }
 }
 
+[data-theme="dark"] {
+  --background: #000000;
+  --background-alt: #1a1a1a;
+  --foreground: #ffffff;
+  --foreground-light: #cccccc;
+  --foreground-muted: #888888;
+  --text-primary: #ffffff;
+  --text-secondary: #cccccc;
+  --text-muted: #888888;
+  --border: #333333;
+  --border-light: #1a1a1a;
+}
+
+[data-theme="light"] {
+  --background: #ffffff;
+  --background-alt: #e9e9e9;
+  --foreground: #000000;
+  --foreground-light: #666666;
+  --foreground-muted: #999999;
+  --text-primary: #000000;
+  --text-secondary: #666666;
+  --text-muted: #999999;
+  --border: #d4d4d4;
+  --border-light: #e9e9e9;
+}
+
 @layer base {
   html {
     font-family: "Univers", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
@@ -180,4 +206,43 @@
   .border-theme-light {
     border-color: var(--border-light);
   }
+
+  .bg-theme-sticky {
+    background-color: var(--background-alt);
+  }
+}
+
+/* Dark mode table refinements */
+[data-theme="dark"] table {
+  color-scheme: dark;
+}
+
+[data-theme="dark"] .bg-secondary-100\/50 {
+  background-color: rgba(30, 30, 30, 0.5);
+}
+
+[data-theme="dark"] .bg-secondary-200\/50 {
+  background-color: rgba(40, 40, 40, 0.5);
+}
+
+[data-theme="dark"] .hover\:bg-primary-100:hover {
+  background-color: rgba(113, 177, 39, 0.15);
+}
+
+/* Scrollbar styling */
+.overflow-y-auto::-webkit-scrollbar {
+  width: 6px;
+}
+
+.overflow-y-auto::-webkit-scrollbar-track {
+  background: var(--background);
+}
+
+.overflow-y-auto::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 3px;
+}
+
+.overflow-y-auto::-webkit-scrollbar-thumb:hover {
+  background: var(--foreground-muted);
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,7 +13,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="de" suppressHydrationWarning>
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,13 +3,16 @@ import ExamScheduleViewer from "@/components/ExamScheduleViewer";
 
 export default function Home() {
   return (
-
     <div className="font-sans min-h-screen bg-theme text-theme-primary">
-      <Suspense fallback={<div className="flex justify-center items-center min-h-screen"><div className="text-lg text-theme-primary">Loading...</div></div>}>
+      <Suspense fallback={
+        <div className="flex justify-center items-center min-h-screen">
+          <div className="text-lg text-theme-primary animate-pulse">Laden...</div>
+        </div>
+      }>
         <ExamScheduleViewer />
       </Suspense>
 
-      <div className="mt-12 px-6 py-8 text-center max-w-2xl mx-auto">
+      <footer className="mt-12 px-6 py-8 text-center max-w-2xl mx-auto">
         <div className="bg-theme-alt backdrop-blur-sm rounded-lg shadow-sm border border-theme p-6">
           <p className="text-lg font-medium text-theme-primary mb-4">
             Nicht der aktuelle Prüfungsplan?
@@ -17,11 +20,7 @@ export default function Home() {
 
           <p className="text-base text-theme-secondary mb-6 leading-relaxed">
             Bitte schreibe{" "}
-            <span
-              className="text-primary-500 hover:text-primary-600 font-semibold 
-                        underline underline-offset-2 hover:underline-offset-4
-                        transition-all duration-200 cursor-pointer"
-            >
+            <span className="text-primary-500 hover:text-primary-600 font-semibold underline underline-offset-2 hover:underline-offset-4 transition-all duration-200 cursor-pointer">
               @entcheneric
             </span>
             {" "}auf Discord und ich werde ihn so schnell wie möglich aktualisieren!
@@ -35,7 +34,7 @@ export default function Home() {
             </p>
           </div>
         </div>
-      </div>
+      </footer>
     </div>
   );
 }

--- a/components/ColumnToggle.tsx
+++ b/components/ColumnToggle.tsx
@@ -12,25 +12,28 @@ export const ColumnToggle: React.FC<ColumnToggleProps> = ({
   onToggleColumn,
 }) => {
   return (
-    <div className="mb-6 flex flex-col items-center gap-4 text-sm select-none">
-      <div className="flex items-center gap-2 text-black-inverse font-medium">
-        <svg className="h-5 w-5 text-black-inverse/70" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <div role="group" aria-label="Column visibility settings" className="mb-6 flex flex-col items-center gap-4 text-sm select-none">
+      <div role="heading" aria-level={3} className="flex items-center gap-2 text-black-inverse font-medium">
+        <svg className="h-5 w-5 text-black-inverse/70" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 17V7m0 10a2 2 0 01-2 2H5a2 2 0 01-2-2V7a2 2 0 012-2h2a2 2 0 012 2m0 10a2 2 0 002 2h2a2 2 0 002-2M9 7a2 2 0 012-2h2a2 2 0 012 2m0 10V7m0 10a2 2 0 002 2h2a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2h2a2 2 0 002-2z" />
         </svg>
-        <span>Spalten anzeigen:</span>
+        <span id="columns-label">Spalten anzeigen:</span>
       </div>
-      <div className="flex flex-wrap justify-center gap-2">
+      <div role="list" aria-labelledby="columns-label" className="flex flex-wrap justify-center gap-2">
         {TABLE_HEADERS.map(({ key, label }) => (
           <label
             key={`toggle-${key}`}
+            role="listitem"
+            htmlFor={`toggle-${key}`}
             className={`flex items-center gap-2 cursor-pointer px-3 py-2 rounded-lg border-2 transition-all duration-200 font-medium text-sm shadow-sm hover:shadow-md ${
               hiddenCols[key]
                 ? "text-black-muted bg-secondary-100 border-secondary-300 hover:bg-secondary-200 hover:border-secondary-400"
                 : "text-primary-700 bg-primary-50 border-primary-200 hover:bg-primary-100 hover:border-primary-300 shadow-primary-100"
             }`}
           >
-            <div className="relative">
+            <div role="checkbox" aria-checked={!hiddenCols[key]} tabIndex={-1}>
               <input
+                id={`toggle-${key}`}
                 type="checkbox"
                 checked={!hiddenCols[key]}
                 onChange={() => onToggleColumn(key)}
@@ -48,7 +51,7 @@ export const ColumnToggle: React.FC<ColumnToggleProps> = ({
                 )}
               </div>
             </div>
-            <span>{label}</span>
+            <span className="ml-1">{label}</span>
           </label>
         ))}
       </div>

--- a/components/ExamScheduleViewer.tsx
+++ b/components/ExamScheduleViewer.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import React, { useEffect, useState, useRef } from "react";
+import React, { useEffect, useState, useCallback } from "react";
 import { ExamEntry } from "@/types/exam";
-import { parseExamSchedulePDF } from "@/utils/pdfParser";
 import { DEFAULT_COLUMN_WIDTHS } from "@/config/tableConfig";
 import { useExamFiltering } from "@/hooks/useExamFiltering";
 import { useUrlSync } from "@/hooks/useUrlSync";
@@ -10,9 +9,15 @@ import { StickyHeader } from "./StickyHeader";
 import { ExamTableHeader } from "./ExamTableHeader";
 import { ExamTableBody } from "./ExamTableBody";
 
+type SortDirection = "asc" | "desc" | null;
+type SortConfig = { key: keyof ExamEntry; direction: SortDirection };
+
 const ExamScheduleViewer = () => {
   const [entries, setEntries] = useState<ExamEntry[]>([]);
-  
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [sort, setSort] = useState<SortConfig>({ key: "datum", direction: "asc" });
+
   const {
     globalSearch,
     columnFilters,
@@ -22,44 +27,74 @@ const ExamScheduleViewer = () => {
     handleToggleColumnVisibility,
   } = useUrlSync();
 
+  const fetchAndParseData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/pruefungsplan");
+      const result = await response.json();
+      if (result.success) {
+        setEntries(result.data);
+      } else {
+        setError(result.error || "Unbekannter Fehler beim Laden");
+      }
+    } catch {
+      setError("Netzwerkfehler — Prüfungsplan konnte nicht geladen werden");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
 
-  const stickyHeaderRef = useRef<HTMLDivElement>(null);
-  const [stickyHeaderHeight, setStickyHeaderHeight] = useState<number>(0);
+  const handleFetchWHS = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/pruefungsplan/fetch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+      const result = await response.json();
+      if (result.success) {
+        setEntries(result.data);
+      } else {
+        setError(result.error || "Fehler beim Laden von der WHS");
+      }
+    } catch {
+      setError("Netzwerkfehler — WHS-Daten konnten nicht geladen werden");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const handleSort = useCallback((key: keyof ExamEntry) => {
+    setSort((prev) => {
+      if (prev.key === key) {
+        const next: SortDirection = prev.direction === "asc" ? "desc" : prev.direction === "desc" ? null : "asc";
+        return { key, direction: next };
+      }
+      return { key, direction: "asc" };
+    });
+  }, []);
 
   useEffect(() => {
-    const fetchAndParseData = async () => {
-      try {
-        const parsedEntries = await parseExamSchedulePDF();
-        setEntries(parsedEntries);
-      } catch (error) {
-        console.error("Error parsing PDF:", error);
-      }
-    };
-
     fetchAndParseData();
-  }, []);
-
-  useEffect(() => {
-    const updateStickyHeaderHeight = () => {
-      if (stickyHeaderRef.current) {
-        setStickyHeaderHeight(stickyHeaderRef.current.offsetHeight);
-      }
-    };
-
-    updateStickyHeaderHeight();
-    window.addEventListener('resize', updateStickyHeaderHeight);
-
-    return () => {
-      window.removeEventListener('resize', updateStickyHeaderHeight);
-    };
-  }, []);
+  }, [fetchAndParseData]);
 
   const filteredEntries = useExamFiltering(entries, globalSearch, columnFilters);
 
+  const sortedEntries = React.useMemo(() => {
+    if (!sort.direction) return filteredEntries;
+    return [...filteredEntries].sort((a, b) => {
+      const aVal = a[sort.key] || "";
+      const bVal = b[sort.key] || "";
+      const cmp = aVal.localeCompare(bVal, "de", { numeric: true });
+      return sort.direction === "asc" ? cmp : -cmp;
+    });
+  }, [filteredEntries, sort]);
 
   return (
     <>
-      <div ref={stickyHeaderRef}>
+      <div>
         <StickyHeader
           hiddenCols={hiddenCols}
           onToggleColumn={handleToggleColumnVisibility}
@@ -67,31 +102,90 @@ const ExamScheduleViewer = () => {
           onGlobalSearchChange={handleGlobalSearchChange}
         />
       </div>
-      
+
       <div className="p-4 max-w-6xl mx-auto font-sans box-border mt-4">
-        <div className="overflow-x-auto rounded-lg shadow-md border border-theme max-h-[480px] overflow-y-auto bg-theme">
-        <table
-          className="w-full min-w-[900px] border-collapse table-fixed user-select-none"
-          role="grid"
-          aria-label="Prüfungsplan Tabelle"
-        >
-          <ExamTableHeader
-            hiddenCols={hiddenCols}
-            colWidths={DEFAULT_COLUMN_WIDTHS}
-            columnFilters={columnFilters}
-            onColumnFilterChange={handleColumnFilterChange}
-            stickyHeaderHeight={stickyHeaderHeight}
-          />
-          <ExamTableBody
-            entries={filteredEntries}
-            hiddenCols={hiddenCols}
-            colWidths={DEFAULT_COLUMN_WIDTHS}
-          />
-        </table>
+        {error && (
+          <div className="mb-4 p-4 rounded-lg border border-error/30 bg-error/10 text-error flex items-start gap-3">
+            <svg className="w-5 h-5 mt-0.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" />
+            </svg>
+            <div>
+              <p className="font-medium">Fehler beim Laden</p>
+              <p className="text-sm mt-1">{error}</p>
+            </div>
+            <button
+              onClick={() => setError(null)}
+              className="ml-auto text-error/70 hover:text-error"
+              aria-label="Fehlermeldung schließen"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        )}
+
+        <div className="overflow-x-auto rounded-lg shadow-md border border-theme bg-theme">
+          {loading ? (
+            <div className="p-8 space-y-3">
+              <div className="h-10 bg-secondary-200/60 rounded animate-pulse" />
+              {[...Array(8)].map((_, i) => (
+                <div key={i} className="h-8 bg-secondary-100/60 rounded animate-pulse" style={{ animationDelay: `${i * 80}ms` }} />
+              ))}
+            </div>
+          ) : (
+            <>
+              <div className="sticky top-0 z-20 bg-theme-sticky shadow-sm border-b border-theme-light">
+                <ExamTableHeader
+                  hiddenCols={hiddenCols}
+                  colWidths={DEFAULT_COLUMN_WIDTHS}
+                  columnFilters={columnFilters}
+                  onColumnFilterChange={handleColumnFilterChange}
+                  sort={sort}
+                  onSort={handleSort}
+                />
+              </div>
+              <div className="max-h-[60vh] overflow-y-auto">
+                <table
+                  className="w-full min-w-[900px] border-collapse table-fixed"
+                  role="grid"
+                  aria-label="Prüfungsplan Tabelle"
+                >
+                  <ExamTableBody
+                    entries={sortedEntries}
+                    hiddenCols={hiddenCols}
+                    colWidths={DEFAULT_COLUMN_WIDTHS}
+                  />
+                </table>
+              </div>
+            </>
+          )}
         </div>
 
-        <div className="mt-5 text-center text-theme-secondary italic text-base select-none">
-          Gefundene Einträge: {filteredEntries.length} / {entries.length}
+        {!loading && (
+          <div className="mt-5 text-center text-theme-secondary italic text-base select-none">
+            Gefundene Einträge: {filteredEntries.length} / {entries.length}
+          </div>
+        )}
+
+        <div className="mt-4 text-center space-y-2">
+          <button
+            onClick={fetchAndParseData}
+            disabled={loading}
+            className="text-sm bg-theme-alt hover:bg-primary-700 hover:text-primary-100 border border-primary-400 px-4 py-1.5 rounded
+                      transition-colors duration-150 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Prü&shy;fungsplan laden
+          </button>
+
+          <button
+            onClick={handleFetchWHS}
+            disabled={loading}
+            className="text-sm bg-primary-600 hover:bg-primary-700 hover:text-primary-100 px-4 py-1.5 rounded
+                      transition-colors duration-150 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Daten von WHS laden
+          </button>
         </div>
       </div>
     </>

--- a/components/ExamTableBody.tsx
+++ b/components/ExamTableBody.tsx
@@ -22,10 +22,15 @@ export const ExamTableBody: React.FC<ExamTableBodyProps> = ({
               TABLE_HEADERS.length -
               Object.values(hiddenCols).filter(Boolean).length
             }
-            className="p-7 text-center italic text-black-muted text-base"
-            role="row"
+            className="p-8 text-center"
           >
-            Keine Einträge gefunden.
+            <div className="flex flex-col items-center gap-2 text-theme-muted">
+              <svg className="w-12 h-12 opacity-40" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <p className="text-lg font-medium">Keine Einträge gefunden</p>
+              <p className="text-sm">Versuche andere Suchbegriffe oder Filter</p>
+            </div>
           </td>
         </tr>
       </tbody>
@@ -36,27 +41,27 @@ export const ExamTableBody: React.FC<ExamTableBodyProps> = ({
     <tbody>
       {entries.map((entry, idx) => (
         <tr
-          key={idx}
+          key={`${entry.mid}-${entry.kuerzel}-${idx}`}
           tabIndex={0}
           aria-rowindex={idx + 1}
-          className={`${idx % 2 === 0 ? "bg-secondary-100" : "bg-secondary-200"
-            } cursor-default transition-colors hover:bg-primary-100 focus:outline-none focus:bg-primary-200 color-black`}
+          className={`${idx % 2 === 0 ? "bg-secondary-100/50" : "bg-secondary-200/50"
+            } transition-colors hover:bg-primary-100 focus:outline-none focus:bg-primary-200 text-theme-primary`}
         >
           {TABLE_HEADERS.map(({ key }) =>
             hiddenCols[key] ? null : (
               <td
                 key={`${idx}-${key}`}
                 data-label={key}
-                className="p-2 text-sm text-black-primary whitespace-nowrap overflow-hidden text-ellipsis"
+                className="p-2 text-sm text-theme-primary whitespace-nowrap overflow-hidden text-ellipsis"
                 style={{
                   width: colWidths[key],
                   minWidth: MIN_COLUMN_WIDTH,
                   maxWidth: 500,
                   boxSizing: "border-box",
                 }}
-                title={entry[key]}
+                title={entry[key] || undefined}
               >
-                {entry[key] || ""}
+                {entry[key] || "—"}
               </td>
             )
           )}

--- a/components/ExamTableHeader.tsx
+++ b/components/ExamTableHeader.tsx
@@ -1,13 +1,39 @@
 import React from "react";
-import { ColumnFilters, ColumnWidths, ColumnVisibility } from "@/types/exam";
+import { ColumnFilters, ColumnWidths, ColumnVisibility, ExamEntry } from "@/types/exam";
 import { TABLE_HEADERS, MIN_COLUMN_WIDTH } from "@/config/tableConfig";
+
+type SortDirection = "asc" | "desc" | null;
+type SortConfig = { key: keyof ExamEntry; direction: SortDirection };
 
 interface ExamTableHeaderProps {
   hiddenCols: ColumnVisibility;
   colWidths: ColumnWidths;
   columnFilters: ColumnFilters;
   onColumnFilterChange: (key: string, value: string) => void;
-  stickyHeaderHeight: number;
+  sort: SortConfig;
+  onSort: (key: keyof ExamEntry) => void;
+}
+
+function SortIcon({ direction }: { direction: SortDirection }) {
+  if (!direction) {
+    return (
+      <svg className="w-3 h-3 text-black-muted/40 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4" />
+      </svg>
+    );
+  }
+  if (direction === "asc") {
+    return (
+      <svg className="w-3 h-3 text-primary ml-1" fill="currentColor" viewBox="0 0 24 24">
+        <path d="M7 14l5-5 5 5z" />
+      </svg>
+    );
+  }
+  return (
+    <svg className="w-3 h-3 text-primary ml-1" fill="currentColor" viewBox="0 0 24 24">
+      <path d="M7 10l5 5 5-5z" />
+    </svg>
+  );
 }
 
 export const ExamTableHeader: React.FC<ExamTableHeaderProps> = ({
@@ -15,57 +41,52 @@ export const ExamTableHeader: React.FC<ExamTableHeaderProps> = ({
   colWidths,
   columnFilters,
   onColumnFilterChange,
-  stickyHeaderHeight,
+  sort,
+  onSort,
 }) => {
   return (
     <thead>
-      <tr className="bg-primary text-black-inverse text-sm select-none sticky top-0 
-               z-10 shadow-sm border-b border-accent-light/20">
+      <tr className="bg-primary text-white text-sm select-none
+               border-b border-accent-light/20">
         {TABLE_HEADERS.map(({ key, label }) =>
           hiddenCols[key] ? null : (
             <th
               key={`header-${key}`}
               scope="col"
               aria-colindex={TABLE_HEADERS.findIndex((h) => h.key === key) + 1}
-              className="sticky z-20 group
-                   bg-gradient-to-b from-white/5 to-transparent
-                   border-r border-accent-light/10 last:border-r-0
+              aria-sort={sort.key === key ? (sort.direction === "asc" ? "ascending" : sort.direction === "desc" ? "descending" : "none") : undefined}
+              className="group
+                   border-r border-white/10 last:border-r-0
                    font-semibold text-left whitespace-nowrap overflow-hidden
                    h-12 px-4 py-3
-                   transition-all duration-200 ease-in-out
-                   hover:bg-white/10 hover:shadow-lg
-                   text-sm tracking-wide uppercase letter-spacing-wide"
+                   transition-colors duration-150
+                   hover:bg-white/10 cursor-pointer
+                   text-sm tracking-wide uppercase"
               style={{
                 width: colWidths[key],
                 minWidth: MIN_COLUMN_WIDTH,
                 maxWidth: 500,
                 boxSizing: "border-box",
               }}
+              onClick={() => onSort(key)}
             >
               <div className="relative flex items-center h-full">
-                <span className="flex-grow pointer-events-none select-none truncate
-                          text-black-inverse/90 group-hover:text-black-inverse
-                          font-medium tracking-wider
-                          transition-colors duration-200">
+                <span className="flex-grow pointer-events-none select-none truncate font-medium tracking-wider">
                   {label}
                 </span>
-
-                <div className="absolute bottom-0 left-0 w-full h-0.5 
-                         bg-gradient-to-r from-accent-light via-accent to-accent-light/50
-                         transform scale-x-0 group-hover:scale-x-100
-                         transition-transform duration-300 ease-out" />
+                <SortIcon direction={sort.key === key ? sort.direction : null} />
               </div>
             </th>
           )
         )}
       </tr>
 
-      <tr className="z-10 select-none text-xs font-medium shadow-sm sticky top-12 bg-white">
+      <tr className="z-10 select-none text-xs font-medium shadow-sm sticky top-12 bg-theme border-b-2 border-secondary-400">
         {TABLE_HEADERS.map(({ key, label }) =>
           hiddenCols[key] ? null : (
             <th
               key={`filter-${key}`}
-              className="border-b-2 border-secondary-400 text-left whitespace-nowrap p-2"
+              className="text-left whitespace-nowrap p-2"
               style={{
                 width: colWidths[key],
                 minWidth: MIN_COLUMN_WIDTH,
@@ -86,13 +107,13 @@ export const ExamTableHeader: React.FC<ExamTableHeaderProps> = ({
                   aria-label={`Filter für ${label}`}
                   spellCheck={false}
                   autoComplete="off"
-                  className="w-full pl-7 pr-2 py-1.5 text-xs border border-secondary-400 rounded-md shadow-sm transition-all duration-200 focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/20 hover:border-secondary-500"
+                  className="w-full pl-7 pr-2 py-1.5 text-xs border border-secondary-400 rounded-md shadow-sm transition-all duration-200 focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/20 hover:border-secondary-500 bg-theme text-theme-primary"
                 />
                 {columnFilters[key] && (
                   <button
-                    onClick={() => onColumnFilterChange(key, "")}
+                    onClick={(e) => { e.stopPropagation(); onColumnFilterChange(key, ""); }}
                     className="absolute inset-y-0 right-0 pr-2 flex items-center text-black-muted hover:text-error transition-colors"
-                    aria-label={`Clear filter for ${label}`}
+                    aria-label={`Filter für ${label} löschen`}
                   >
                     <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />

--- a/components/GlobalSearch.tsx
+++ b/components/GlobalSearch.tsx
@@ -13,7 +13,7 @@ export const GlobalSearch: React.FC<GlobalSearchProps> = ({
     <div className="flex gap-2 flex-wrap">
       <div className="relative flex-grow min-w-[200px]">
         <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-          <svg className="h-4 w-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="h-4 w-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
           </svg>
         </div>
@@ -21,23 +21,29 @@ export const GlobalSearch: React.FC<GlobalSearchProps> = ({
           type="text"
           value={globalSearch}
           onChange={(e) => onGlobalSearchChange(e.target.value)}
-          placeholder="Durchsuche alle Spalten..."
+          placeholder="Suche in allen Spalten..."
           aria-label="Globale Suche"
+          aria-describedby="search-hint"
+          id="global-search"
           spellCheck={false}
           autoComplete="off"
-          className="w-full pl-9 pr-4 py-2 text-sm border border-theme/30 rounded-lg backdrop-blur-sm text-black-inverse placeholder-theme-inverse/60 transition-all duration-200 focus:outline-none focus:border-theme/50"
+          className="w-full pl-9 pr-4 py-2 text-sm border border-theme/30 rounded-lg backdrop-blur-sm text-black-inverse placeholder-theme-inverse/60 transition-all duration-200 focus:outline-none focus:border-theme/50 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
         />
+        <span id="search-hint" className="sr-only">
+          Suche nach Klauseltiteln, -daten oder -orten. Ergebnisse werden live aktualisiert.
+        </span>
       </div>
       {globalSearch && (
         <button
           onClick={() => onGlobalSearchChange("")}
-          aria-label="Clear global search"
-          className="hover:bg-error/80 border border-theme/30 hover:border-error text-black-inverse font-medium px-3 py-2 rounded-lg backdrop-blur-sm transition-all duration-200 flex items-center gap-1 text-sm"
+          aria-label="Globale Suche zurücksetzen"
+          className="hover:bg-error/80 border border-theme/30 hover:border-error text-black-inverse font-medium px-3 py-2 rounded-lg backdrop-blur-sm transition-all duration-200 flex items-center gap-1 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
         >
-          <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
           </svg>
-          Clear
+          Löschen
+          <span className="sr-only">Suchfeld leeren</span>
         </button>
       )}
     </div>

--- a/components/ShareUrlButton.tsx
+++ b/components/ShareUrlButton.tsx
@@ -45,13 +45,14 @@ export const ShareUrlButton: React.FC = () => {
     <div className="relative">
       <button
         onClick={handleShareUrl}
-        className="bg-primary/80 hover:bg-primary border border-primary/30 text-white font-medium px-4 py-2 rounded-lg backdrop-blur-sm transition-all duration-200 flex items-center gap-2 text-sm"
-        aria-label="Share current URL with filters"
+        className="bg-primary/80 hover:bg-primary border border-primary/30 text-white font-medium px-4 py-2 rounded-lg backdrop-blur-sm transition-all duration-200 flex items-center gap-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
+        aria-label="Link zu aktuellen Filtern kopieren und teilen"
       >
-        <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.367 2.684 3 3 0 00-5.367-2.684z" />
         </svg>
         URL teilen
+        <span className="sr-only">in Zwischenablage kopieren</span>
       </button>
       
       {showToast && (

--- a/components/StickyHeader.tsx
+++ b/components/StickyHeader.tsx
@@ -19,29 +19,45 @@ export const StickyHeader: React.FC<StickyHeaderProps> = ({
   globalSearch,
   onGlobalSearchChange,
 }) => {
+  const [isDark, setIsDark] = React.useState(false);
+
+  React.useEffect(() => {
+    const stored = localStorage.getItem("theme");
+    const prefersDark = stored === "dark" || (!stored && window.matchMedia("(prefers-color-scheme: dark)").matches);
+    setIsDark(prefersDark);
+    document.documentElement.setAttribute("data-theme", prefersDark ? "dark" : "light");
+  }, []);
+
+  const toggleTheme = () => {
+    const next = !isDark;
+    setIsDark(next);
+    document.documentElement.setAttribute("data-theme", next ? "dark" : "light");
+    localStorage.setItem("theme", next ? "dark" : "light");
+  };
+
   return (
-    <header className="sticky top-0 z-50 bg-gradient-to-r from-primary via-primary-600 to-primary shadow-lg border-b-2 border-primary-700">
+    <header role="banner" className="sticky top-0 z-50 bg-gradient-to-r from-primary via-primary-600 to-primary shadow-lg border-b-2 border-primary-700">
       <div className="max-w-6xl mx-auto px-4 py-4">
         <div className="text-center mb-4">
-          <h1 className="text-3xl font-bold text-white mb-2 tracking-wide">
-            📅 Better Prüfungsplan - Stand Dezember 2025
+          <h1 id="app-title" className="text-3xl font-bold text-white mb-2 tracking-wide">
+            Better Prüfungsplan
           </h1>
-          <div className="h-1 w-32 bg-gradient-to-r from-primary-300 to-primary-200 mx-auto rounded-full"></div>
+          <div className="h-1 w-32 bg-gradient-to-r from-primary-300 to-primary-200 mx-auto rounded-full" aria-hidden="true" />
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 items-start">
-          <div className="backdrop-blur-sm rounded-lg p-3 border border-theme/20">
+          <div className="backdrop-blur-sm rounded-lg p-3 border border-white/20">
             <h3 className="text-sm font-semibold text-white mb-2 flex items-center">
               <span className="mr-2">👁️</span>
               Spalten verwalten
             </h3>
-            <ColumnToggle 
+            <ColumnToggle
               hiddenCols={hiddenCols}
               onToggleColumn={onToggleColumn}
             />
           </div>
 
-          <div className="backdrop-blur-sm rounded-lg p-3 border border-theme/20">
+          <div className="backdrop-blur-sm rounded-lg p-3 border border-white/20">
             <h3 className="text-sm font-semibold text-white mb-2 flex items-center">
               <span className="mr-2">🔍</span>
               Globale Suche
@@ -51,7 +67,25 @@ export const StickyHeader: React.FC<StickyHeaderProps> = ({
                 globalSearch={globalSearch}
                 onGlobalSearchChange={onGlobalSearchChange}
               />
-              <ShareUrlButton />
+              <div className="flex items-center gap-2">
+                <ShareUrlButton />
+                <button
+                  onClick={toggleTheme}
+                  className="bg-white/20 hover:bg-white/30 border border-white/30 text-white font-medium px-4 py-2 rounded-lg backdrop-blur-sm transition-all duration-200 flex items-center gap-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
+                  aria-label={isDark ? "Zum hellen Modus wechseln" : "Zum dunklen Modus wechseln"}
+                >
+                  {isDark ? (
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                  ) : (
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                  )}
+                  {isDark ? "Hell" : "Dunkel"}
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/components/ThemeProvider.tsx
+++ b/components/ThemeProvider.tsx
@@ -6,11 +6,12 @@ export default function ThemeProvider({ children }: { children: React.ReactNode 
   useEffect(() => {
     const savedTheme = localStorage.getItem('theme');
     const root = document.documentElement;
-    
+
     if (savedTheme === 'light' || savedTheme === 'dark') {
       root.setAttribute('data-theme', savedTheme);
     } else {
-      root.removeAttribute('data-theme');
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      root.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
     }
   }, []);
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  const response = NextResponse.next();
+
+  // Security headers
+  response.headers.set('X-Frame-Options', 'DENY');
+  response.headers.set('X-Content-Type-Options', 'nosniff');
+  response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
+  response.headers.set(
+    'Content-Security-Policy',
+    "default-src 'self'; " +
+    "script-src 'self' https://fonts.googleapis.com; " +
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
+    "img-src 'self' data: https:; " +
+    "font-src 'self' https://fonts.gstatic.com; " +
+    "connect-src 'self'"
+  );
+
+  return response;
+}
+
+export const config = {
+  matcher: [
+    '/((?!api|_next/static|_next/image|favicon.ico).*)',
+  ],
+};

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  turbo: {
-    root: __dirname,
-  },
+  output: "standalone",
 };
 
 export default nextConfig;

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,2 @@
+// Re-export the canonical exam types
+export type { ExamEntry, TableHeader, ColumnFilters, ColumnVisibility, ColumnWidths, ResizeInfo } from "./exam";

--- a/utils/pdfParser.ts
+++ b/utils/pdfParser.ts
@@ -2,10 +2,10 @@ import { PdfDocument } from "pdf-tables-parser";
 import { Buffer } from "buffer";
 import { ExamEntry } from "@/types/exam";
 
-const mapRowToEntry = (row: string[]): ExamEntry | null => {
+export const mapRowToEntry = (row: string[]): ExamEntry | null => {
   if (row.length < 8) return null;
   return {
-    mid: row[0].trim(),
+    mid: row[0]?.trim() || "",
     kuerzel: row[1]?.trim() || "",
     po: row[2]?.trim() || "",
     lp: row[3]?.trim() || "",
@@ -18,7 +18,7 @@ const mapRowToEntry = (row: string[]): ExamEntry | null => {
   };
 };
 
-const normalizeRow = (rowData: string[] | string): string[] => {
+export const normalizeRow = (rowData: string[] | string): string[] => {
   if (Array.isArray(rowData)) {
     return rowData.join(" ").trim().split(/\s{2,}|\t+/);
   }
@@ -45,11 +45,46 @@ export const parseExamSchedulePDF = async (): Promise<ExamEntry[]> => {
   pages.forEach((page) => {
     page.tables.forEach((table) => {
       table.data.forEach((row) => {
-        const singleArrayElement = [row.flat()];
-        const cols = normalizeRow(singleArrayElement[0]);
+        const cols = normalizeRow(row.flat());
         const entry = mapRowToEntry(cols);
         if (
-          entry !== null &&
+          entry &&
+          !["mid", "MID", "kuerzel", "Kürzel"].includes(entry.mid.toLowerCase())
+        ) {
+          allEntries.push(entry);
+        }
+      });
+    });
+  });
+
+  return allEntries;
+};
+
+export const fetchExamSchedulePDF = async (url: string): Promise<ExamEntry[]> => {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch PDF: ${response.statusText}`);
+  }
+  const arrayBuffer = await response.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+
+  const pdfDoc = new PdfDocument({
+    hasTitles: true,
+    threshold: 1.5,
+    maxStrLength: 100,
+    ignoreTexts: [],
+  });
+
+  await pdfDoc.load(buffer);
+
+  const allEntries: ExamEntry[] = [];
+  pdfDoc.pages.forEach((page) => {
+    page.tables.forEach((table) => {
+      table.data.forEach((row) => {
+        const cols = normalizeRow(row.flat());
+        const entry = mapRowToEntry(cols);
+        if (
+          entry &&
           !["mid", "MID", "kuerzel", "Kürzel"].includes(entry.mid.toLowerCase())
         ) {
           allEntries.push(entry);


### PR DESCRIPTION
…ploy

- Fix route.ts: remove broken sessionStorage usage (server-side), use shared ExamEntry type, add server-side cache with 5min TTL
- Deduplicate mapRowToEntry/normalizeRow into pdfParser.ts exports
- Fix input-validation.ts ReferenceError (missing let declaration)
- Fix "Prüungsplan" typo
- Remove broken auth system (demo login, localStorage passwords, middleware blocking all routes)
- Remove unused/broken components (ExamsPage, WhsPdfFetchForm, AuthHeader, ErrorBoundary, LoadingSkeleton, DataExportPanel, SettingsPanel, auth pages, input-validation, tests)
- Clean up types/index.ts (was importing non-existent exports)
- Add loading skeleton state while data fetches
- Add error state with dismissable banner on fetch failure
- Add table column sorting (click headers for asc/desc)
- Add dark mode toggle button in header (persists to localStorage)
- Add data-theme CSS variables for explicit dark/light mode switching
- Fix filter row hardcoded bg-white (breaks in dark mode)
- Change GlobalSearch "Clear" button to German "Löschen"
- Improve empty state with icon and helpful text
- Show em-dash for empty cells instead of blank
- Remove next.config.ts invalid turbo option (fixes build warning)
- Add Dockerfile + .dockerignore for Coolify deployment
- Enable standalone output in next.config for minimal Docker image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dark/light theme toggle for improved visual preference support
  * Implemented sortable columns in the exam schedule table
  * Added API endpoints for loading exam schedule data
  * Docker containerization support

* **Improvements**
  * Enhanced dark mode styling and visual consistency
  * Improved accessibility with semantic markup and ARIA labels
  * Better error messaging and loading states
  * Added security headers for enhanced protection
  * Set application language to German

<!-- end of auto-generated comment: release notes by coderabbit.ai -->