### PR TITLE
Fix Dockerfile: install dev dependencies for build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM base AS deps
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 COPY package.json package-lock.json ./
-RUN npm ci --omit=dev
+RUN npm ci
 
 FROM base AS builder
 WORKDIR /app


### PR DESCRIPTION
npm ci --omit=dev skipped TypeScript and TailwindCSS, causing MODULE_NOT_FOUND when next build tried to load next.config.ts. Dev deps are needed at build time; only standalone output lands in the final image.