### PR TITLE
Add client-side PDF fetch on reload, force cache refresh, resizable c…

### DIFF
--- a/app/api/pruefungsplan/route.ts
+++ b/app/api/pruefungsplan/route.ts
@@ -57,9 +57,12 @@ async function parsePdfFromUrl(url: string): Promise<ExamEntry[]> {
   return allEntries;
 }
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
-    if (isCacheValid()) {
+    const url = new URL(request.url);
+    const forceRefresh = url.searchParams.get("refresh") === "1";
+
+    if (!forceRefresh && isCacheValid()) {
       return NextResponse.json({
         success: true,
         data: cachedData,
@@ -113,11 +116,25 @@ export async function GET() {
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
+
+    // Client sent parsed data to update server cache
+    if (body.data && Array.isArray(body.data)) {
+      cachedData = body.data as ExamEntry[];
+      cachedAt = Date.now();
+      return NextResponse.json({
+        success: true,
+        data: cachedData,
+        count: cachedData.length,
+        cached: false,
+        source: "client",
+      });
+    }
+
     const { url } = body;
 
     if (!url || typeof url !== "string") {
       return NextResponse.json(
-        { success: false, error: "URL ist erforderlich" },
+        { success: false, error: "URL ist erforderlich oder data muss ein Array sein" },
         { status: 400 }
       );
     }

--- a/components/ExamScheduleViewer.tsx
+++ b/components/ExamScheduleViewer.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import React, { useEffect, useState, useCallback, useMemo } from "react";
-import { ExamEntry } from "@/types/exam";
-import { DEFAULT_COLUMN_WIDTHS } from "@/config/tableConfig";
+import { ExamEntry, ColumnWidths } from "@/types/exam";
+import { DEFAULT_COLUMN_WIDTHS, MIN_COLUMN_WIDTH } from "@/config/tableConfig";
 import { useExamFiltering } from "@/hooks/useExamFiltering";
 import { useUrlSync } from "@/hooks/useUrlSync";
+import { parsePDFClientSide } from "@/utils/pdfParser";
 import { StickyHeader } from "./StickyHeader";
 import { ExamTableHeader } from "./ExamTableHeader";
 import { ExamTableBody } from "./ExamTableBody";
+
+const WHS_PDF_URL = "https://www.w-hs.de/fileadmin/Oeffentlich/Fachbereich-3/informatik/info-center/bekanntmachungen/pp_2026_ib.pdf";
 
 type SortDirection = "asc" | "desc" | null;
 type SortConfig = { key: keyof ExamEntry; direction: SortDirection };
@@ -40,11 +43,43 @@ const ExamScheduleViewer = () => {
     return cols;
   }, [hiddenCols, studiengang]);
 
-  const fetchAndParseData = useCallback(async () => {
+  const fetchAndParseData = useCallback(async (forceRefresh = false) => {
     setLoading(true);
     setError(null);
     try {
-      const response = await fetch("/api/pruefungsplan");
+      if (forceRefresh) {
+        // Try client-side PDF fetch first to avoid server IP blocks
+        try {
+          const pdfResponse = await fetch(WHS_PDF_URL, {
+            headers: {
+              "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+            },
+          });
+          if (pdfResponse.ok) {
+            const arrayBuffer = await pdfResponse.arrayBuffer();
+            const data = await parsePDFClientSide(arrayBuffer);
+            if (data.length > 0) {
+              setEntries(data);
+              // Update server cache so other users benefit
+              try {
+                await fetch("/api/pruefungsplan", {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({ data }),
+                });
+              } catch {
+                // Silently ignore cache update failures
+              }
+              setLoading(false);
+              return;
+            }
+          }
+        } catch (clientError) {
+          console.warn("Client-side PDF fetch failed, falling back to server:", clientError);
+        }
+      }
+
+      const response = await fetch(`/api/pruefungsplan${forceRefresh ? "?refresh=1" : ""}`);
       const result = await response.json();
       if (result.success) {
         setEntries(result.data);
@@ -67,6 +102,56 @@ const ExamScheduleViewer = () => {
       return { key, direction: "asc" };
     });
   }, []);
+
+  // Column widths state with localStorage persistence
+  const [colWidths, setColWidths] = useState<ColumnWidths>(() => {
+    if (typeof window !== "undefined") {
+      try {
+        const stored = localStorage.getItem("exam-column-widths");
+        if (stored) {
+          const parsed = JSON.parse(stored);
+          return { ...DEFAULT_COLUMN_WIDTHS, ...parsed };
+        }
+      } catch {
+        // ignore invalid stored data
+      }
+    }
+    return DEFAULT_COLUMN_WIDTHS;
+  });
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      localStorage.setItem("exam-column-widths", JSON.stringify(colWidths));
+    }
+  }, [colWidths]);
+
+  // Column resize handlers
+  const [resizing, setResizing] = useState<{ colKey: string; startX: number; startWidth: number } | null>(null);
+
+  const handleResizeStart = useCallback((colKey: string, startX: number, startWidth: number) => {
+    setResizing({ colKey, startX, startWidth });
+  }, []);
+
+  useEffect(() => {
+    if (!resizing) return;
+
+    const handleMouseMove = (e: MouseEvent) => {
+      const delta = e.clientX - resizing.startX;
+      const newWidth = Math.max(MIN_COLUMN_WIDTH, resizing.startWidth + delta);
+      setColWidths((prev) => ({ ...prev, [resizing.colKey]: newWidth }));
+    };
+
+    const handleMouseUp = () => {
+      setResizing(null);
+    };
+
+    window.addEventListener("mousemove", handleMouseMove);
+    window.addEventListener("mouseup", handleMouseUp);
+    return () => {
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, [resizing]);
 
   useEffect(() => {
     fetchAndParseData();
@@ -139,18 +224,19 @@ const ExamScheduleViewer = () => {
                 <thead className="sticky top-0 z-20 bg-theme-sticky shadow-sm">
                   <ExamTableHeader
                     hiddenCols={effectiveHiddenCols}
-                    colWidths={DEFAULT_COLUMN_WIDTHS}
+                    colWidths={colWidths}
                     columnFilters={columnFilters}
                     onColumnFilterChange={handleColumnFilterChange}
                     sort={sort}
                     onSort={handleSort}
+                    onResizeStart={handleResizeStart}
                   />
                 </thead>
                 <tbody>
                   <ExamTableBody
                   entries={sortedEntries}
                   hiddenCols={effectiveHiddenCols}
-                  colWidths={DEFAULT_COLUMN_WIDTHS}
+                  colWidths={colWidths}
                 />
                 </tbody>
               </table>
@@ -166,7 +252,7 @@ const ExamScheduleViewer = () => {
 
         <div className="mt-4 flex justify-center">
           <button
-            onClick={fetchAndParseData}
+            onClick={() => fetchAndParseData(true)}
             disabled={loading}
             className="text-sm bg-primary-600 hover:bg-primary-700 hover:text-primary-100 px-4 py-1.5 rounded
                       transition-colors duration-150 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"

--- a/components/ExamTableHeader.tsx
+++ b/components/ExamTableHeader.tsx
@@ -12,6 +12,7 @@ interface ExamTableHeaderProps {
   onColumnFilterChange: (key: string, value: string) => void;
   sort: SortConfig;
   onSort: (key: keyof ExamEntry) => void;
+  onResizeStart: (colKey: string, startX: number, startWidth: number) => void;
 }
 
 function SortIcon({ direction }: { direction: SortDirection }) {
@@ -43,6 +44,7 @@ export const ExamTableHeader: React.FC<ExamTableHeaderProps> = ({
   onColumnFilterChange,
   sort,
   onSort,
+  onResizeStart,
 }) => {
   return (
     <>
@@ -61,7 +63,7 @@ export const ExamTableHeader: React.FC<ExamTableHeaderProps> = ({
                    h-12 px-4 py-3
                    transition-colors duration-150
                    hover:bg-white/10 cursor-pointer
-                   text-sm tracking-wide uppercase"
+                   text-sm tracking-wide uppercase relative"
               style={{
                 width: colWidths[key],
                 minWidth: MIN_COLUMN_WIDTH,
@@ -76,6 +78,18 @@ export const ExamTableHeader: React.FC<ExamTableHeaderProps> = ({
                 </span>
                 <SortIcon direction={sort.key === key ? sort.direction : null} />
               </div>
+              <div
+                className="absolute right-0 top-0 bottom-0 w-2 cursor-col-resize hover:bg-white/30 active:bg-white/50 transition-colors z-10"
+                onMouseDown={(e) => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                  const rect = (e.target as HTMLElement).parentElement?.getBoundingClientRect();
+                  if (rect) {
+                    onResizeStart(key, e.clientX, rect.width);
+                  }
+                }}
+                title="Spaltenbreite anpassen"
+              />
             </th>
           )
         )}

--- a/config/tableConfig.ts
+++ b/config/tableConfig.ts
@@ -114,6 +114,8 @@ export const DEFAULT_HIDDEN_COLUMNS = [
   "mid",
   "lp",
   "beisitzer",
+  "erstpruefer",
+  "zweitpruefer",
   "pi_ba",
   "ti_ba",
   "mi_ba",

--- a/utils/pdfParser.ts
+++ b/utils/pdfParser.ts
@@ -106,3 +106,38 @@ export const fetchExamSchedulePDF = async (url: string): Promise<ExamEntry[]> =>
   const pdfDoc = await loadPdf(arrayBuffer);
   return extractEntries(pdfDoc);
 };
+
+// Client-side PDF parsing using dynamic imports to avoid bundling issues
+// if pdf-tables-parser is Node-only. Falls back to server-side parsing on failure.
+export const parsePDFClientSide = async (arrayBuffer: ArrayBuffer): Promise<ExamEntry[]> => {
+  const [{ PdfDocument }, { Buffer }] = await Promise.all([
+    import("pdf-tables-parser"),
+    import("buffer"),
+  ]);
+
+  const uint8 = new Uint8Array(arrayBuffer);
+  const pdfDoc = new PdfDocument({
+    hasTitles: true,
+    threshold: 1.5,
+    maxStrLength: 100,
+    ignoreTexts: [],
+  });
+  await pdfDoc.load(uint8 as unknown as Buffer);
+
+  const allEntries: ExamEntry[] = [];
+  const headerKeywords = new Set(["mid", "MID", "kuerzel", "Kürzel", "kürzel"]);
+
+  pdfDoc.pages.forEach((page) => {
+    page.tables.forEach((table) => {
+      table.data.forEach((row) => {
+        const cols = normalizeRow(row.flat());
+        const entry = mapRowToEntry(cols);
+        if (entry && !headerKeywords.has(entry.mid.toLowerCase())) {
+          allEntries.push(entry);
+        }
+      });
+    });
+  });
+
+  return allEntries;
+};


### PR DESCRIPTION
…olumns

- "Neu laden" now bypasses the 5-min server cache via ?refresh=1
- Client-side PDF fetch from WHS server to avoid IP blocks/rate limits
- Server cache updated via POST from parsed client data
- Default-hide erstpruefer and zweitpruefer columns
- Resizable table columns with localStorage persistence

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Interactive column resizing with persistent column widths across sessions.
  * Force-refresh option to bypass cached exam schedule data.
  * Client-side exam data parsing and upload capability.

* **Changes**
  * `Erstprüfer` and `Zweitprüfer` columns now hidden by default for improved table readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->